### PR TITLE
fix(generate-schema): improve TypeError for invalid JSON value

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,12 @@ Output:
 }
 ```
 
+An error will be thrown for an invalid JSON value:
+
+```ts
+generateSchema(undefined); // Uncaught TypeError: Invalid JSON value: undefined
+```
+
 ## Release
 
 Release is automated with [Release Please](https://github.com/googleapis/release-please).

--- a/src/generate-schema.test.ts
+++ b/src/generate-schema.test.ts
@@ -5,7 +5,7 @@ describe('invalid JSON value', () => {
     'throws error for %p',
     (value) => {
       expect(() => generateSchema(value)).toThrow(
-        new TypeError('First argument must be a JSON value'),
+        new TypeError(`Invalid JSON value: ${String(value)}`),
       );
     },
   );

--- a/src/generate-schema.ts
+++ b/src/generate-schema.ts
@@ -1,7 +1,5 @@
 import { deepEqual } from './utils';
 
-const error = new TypeError('First argument must be a JSON value');
-
 /**
  * Generate JSON schema from value.
  *
@@ -16,7 +14,7 @@ export function generateSchema(value: any): any {
     case typeof value === 'function':
     case typeof value === 'symbol':
     case value instanceof Date:
-      throw error;
+      throw new TypeError(`Invalid JSON value: ${String(value)}`);
 
     case value === null:
       return { type: 'null' };
@@ -66,6 +64,6 @@ export function generateSchema(value: any): any {
 
     /* istanbul ignore next */
     default:
-      throw error;
+      throw new TypeError(`Invalid JSON value: ${value}`);
   }
 }


### PR DESCRIPTION
## What is the motivation for this pull request?

fix(generate-schema): improve TypeError for invalid JSON value

## What is the current behavior?

```
First argument must be a JSON value
```

## What is the new behavior?

```
Invalid JSON value: {value}
```

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests
- [x] Documentation