### PR TITLE
feat(generate-schema): add additional formats for string type

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,9 @@
       "version": "1.1.1",
       "hasInstallScript": true,
       "license": "MIT",
+      "dependencies": {
+        "validator": "13.11.0"
+      },
       "devDependencies": {
         "@commitlint/cli": "17.7.1",
         "@commitlint/config-conventional": "17.7.0",
@@ -6954,6 +6957,14 @@
         "spdx-expression-parse": "^3.0.0"
       }
     },
+    "node_modules/validator": {
+      "version": "13.11.0",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.11.0.tgz",
+      "integrity": "sha512-Ii+sehpSfZy+At5nPdnyMhx78fEoPDkR2XW/zimHEL3MyGJQOCQ7WeP20jPYRz7ZCpcKLB21NxuXHF3bxjStBQ==",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/vscode-oniguruma": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-1.7.0.tgz",
@@ -12215,6 +12226,11 @@
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
       }
+    },
+    "validator": {
+      "version": "13.11.0",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.11.0.tgz",
+      "integrity": "sha512-Ii+sehpSfZy+At5nPdnyMhx78fEoPDkR2XW/zimHEL3MyGJQOCQ7WeP20jPYRz7ZCpcKLB21NxuXHF3bxjStBQ=="
     },
     "vscode-oniguruma": {
       "version": "1.7.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
+        "@types/validator": "13.11.1",
         "validator": "13.11.0"
       },
       "devDependencies": {
@@ -1725,6 +1726,11 @@
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.1.tgz",
       "integrity": "sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==",
       "dev": true
+    },
+    "node_modules/@types/validator": {
+      "version": "13.11.1",
+      "resolved": "https://registry.npmjs.org/@types/validator/-/validator-13.11.1.tgz",
+      "integrity": "sha512-d/MUkJYdOeKycmm75Arql4M5+UuXmf4cHdHKsyw1GcvnNgL6s77UkgSgJ8TE/rI5PYsnwYq5jkcWBLuN/MpQ1A=="
     },
     "node_modules/@types/yargs": {
       "version": "17.0.20",
@@ -8531,6 +8537,11 @@
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.1.tgz",
       "integrity": "sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==",
       "dev": true
+    },
+    "@types/validator": {
+      "version": "13.11.1",
+      "resolved": "https://registry.npmjs.org/@types/validator/-/validator-13.11.1.tgz",
+      "integrity": "sha512-d/MUkJYdOeKycmm75Arql4M5+UuXmf4cHdHKsyw1GcvnNgL6s77UkgSgJ8TE/rI5PYsnwYq5jkcWBLuN/MpQ1A=="
     },
     "@types/yargs": {
       "version": "17.0.20",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,9 @@
     "js",
     "document"
   ],
+  "dependencies": {
+    "validator": "13.11.0"
+  },
   "devDependencies": {
     "@commitlint/cli": "17.7.1",
     "@commitlint/config-conventional": "17.7.0",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "document"
   ],
   "dependencies": {
+    "@types/validator": "13.11.1",
     "validator": "13.11.0"
   },
   "devDependencies": {

--- a/src/generate-schema.test.ts
+++ b/src/generate-schema.test.ts
@@ -38,6 +38,15 @@ describe('string', () => {
       });
     });
   });
+
+  describe('date', () => {
+    it.each(['2018-11-13'])('converts %p', (value) => {
+      expect(generateSchema(value)).toEqual({
+        type: 'string',
+        format: 'date',
+      });
+    });
+  });
 });
 
 describe('integer', () => {

--- a/src/generate-schema.test.ts
+++ b/src/generate-schema.test.ts
@@ -12,8 +12,19 @@ describe('invalid JSON value', () => {
 });
 
 describe('string', () => {
-  it.each(['', 'foo'])('converts %p', (value) => {
-    expect(generateSchema(value)).toEqual({ type: 'string' });
+  describe('default', () => {
+    it.each(['', 'foo'])('converts %p', (value) => {
+      expect(generateSchema(value)).toEqual({ type: 'string' });
+    });
+  });
+
+  describe('date-time', () => {
+    it.each(['2018-11-13T20:20:39+00:00'])('converts %p', (value) => {
+      expect(generateSchema(value)).toEqual({
+        type: 'string',
+        format: 'date-time',
+      });
+    });
   });
 });
 

--- a/src/generate-schema.test.ts
+++ b/src/generate-schema.test.ts
@@ -47,6 +47,15 @@ describe('string', () => {
       });
     });
   });
+
+  describe('email', () => {
+    it.each(['user@example.com'])('converts %p', (value) => {
+      expect(generateSchema(value)).toEqual({
+        type: 'string',
+        format: 'email',
+      });
+    });
+  });
 });
 
 describe('integer', () => {

--- a/src/generate-schema.test.ts
+++ b/src/generate-schema.test.ts
@@ -19,10 +19,22 @@ describe('string', () => {
   });
 
   describe('date-time', () => {
-    it.each(['2018-11-13T20:20:39+00:00'])('converts %p', (value) => {
+    it.each(['2018-11-13T20:20:39+00:00', '2022-11-02T09:03:19.967Z'])(
+      'converts %p',
+      (value) => {
+        expect(generateSchema(value)).toEqual({
+          type: 'string',
+          format: 'date-time',
+        });
+      },
+    );
+  });
+
+  describe('time', () => {
+    it.each(['20:20:39+00:00', '20:20:39'])('converts %p', (value) => {
       expect(generateSchema(value)).toEqual({
         type: 'string',
-        format: 'date-time',
+        format: 'time',
       });
     });
   });

--- a/src/generate-schema.ts
+++ b/src/generate-schema.ts
@@ -45,6 +45,10 @@ export function generateSchema(value: any): any {
         return { type: 'string', format: 'time' };
       }
 
+      if (validator.isEmail(value)) {
+        return { type: 'string', format: 'email' };
+      }
+
       return { type: 'string' };
 
     case Array.isArray(value):

--- a/src/generate-schema.ts
+++ b/src/generate-schema.ts
@@ -18,15 +18,21 @@ export function generateSchema(value: any): any {
     case value instanceof Date:
       throw new TypeError(`Invalid JSON value: ${String(value)}`);
 
+    /**
+     * @see https://json-schema.org/understanding-json-schema/reference/null.html
+     */
     case value === null:
       return { type: 'null' };
 
-    case Number.isInteger(value):
-      return { type: 'integer' };
-
+    /**
+     * @see https://json-schema.org/understanding-json-schema/reference/numeric.html
+     */
     case typeof value === 'number':
-      return { type: 'number' };
+      return { type: Number.isInteger(value) ? 'integer' : 'number' };
 
+    /**
+     * @see https://json-schema.org/understanding-json-schema/reference/boolean.html
+     */
     case typeof value === 'boolean':
       return { type: 'boolean' };
 
@@ -51,6 +57,9 @@ export function generateSchema(value: any): any {
 
       return { type: 'string' };
 
+    /**
+     * @see https://json-schema.org/understanding-json-schema/reference/array.html
+     */
     case Array.isArray(value):
       if (value.length === 1) {
         return { type: 'array', items: generateSchema(value[0]) };
@@ -65,6 +74,9 @@ export function generateSchema(value: any): any {
 
       return { type: 'array' };
 
+    /**
+     * @see https://json-schema.org/understanding-json-schema/reference/object.html
+     */
     case value instanceof Object:
       if (!Object.keys(value).length) {
         return { type: 'object' };

--- a/src/generate-schema.ts
+++ b/src/generate-schema.ts
@@ -37,6 +37,11 @@ export function generateSchema(value: any): any {
       if (validator.isISO8601(value)) {
         return { type: 'string', format: 'date-time' };
       }
+
+      if (validator.isTime(value.split('+')[0], { mode: 'withSeconds' })) {
+        return { type: 'string', format: 'time' };
+      }
+
       return { type: 'string' };
 
     case Array.isArray(value):

--- a/src/generate-schema.ts
+++ b/src/generate-schema.ts
@@ -35,7 +35,10 @@ export function generateSchema(value: any): any {
      */
     case typeof value === 'string':
       if (validator.isISO8601(value)) {
-        return { type: 'string', format: 'date-time' };
+        return {
+          type: 'string',
+          format: value.includes('T') ? 'date-time' : 'date',
+        };
       }
 
       if (validator.isTime(value.split('+')[0], { mode: 'withSeconds' })) {

--- a/src/generate-schema.ts
+++ b/src/generate-schema.ts
@@ -1,3 +1,5 @@
+import validator from 'validator';
+
 import { deepEqual } from './utils';
 
 /**
@@ -25,11 +27,17 @@ export function generateSchema(value: any): any {
     case typeof value === 'number':
       return { type: 'number' };
 
-    case typeof value === 'string':
-      return { type: 'string' };
-
     case typeof value === 'boolean':
       return { type: 'boolean' };
+
+    /**
+     * @see https://json-schema.org/understanding-json-schema/reference/string.html
+     */
+    case typeof value === 'string':
+      if (validator.isISO8601(value)) {
+        return { type: 'string', format: 'date-time' };
+      }
+      return { type: 'string' };
 
     case Array.isArray(value):
       if (value.length === 1) {


### PR DESCRIPTION
## What is the motivation for this pull request?

feat(generate-schema): add additional formats for string type:

- date-time
- time
- date
- email

https://github.com/validatorjs/validator.js

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests
- [ ] Documentation